### PR TITLE
[Docs]: Add Box64 RC File Docs, Update SoC List, and Improve Link Formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/compat_report_bionic.yaml
+++ b/.github/ISSUE_TEMPLATE/compat_report_bionic.yaml
@@ -141,8 +141,9 @@ body:
       - G3X Gen2
       - 8 Gen2
       - 8 Gen1
-      - sd888
-      - sd870
+      - SD888
+      - SD870
+      - SD865
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/compat_report_glibc.yaml
+++ b/.github/ISSUE_TEMPLATE/compat_report_glibc.yaml
@@ -270,8 +270,9 @@ body:
       - G3X Gen2
       - 8 Gen2
       - 8 Gen1
-      - sd888
-      - sd870
+      - SD888
+      - SD870
+      - SD865
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Winlator is an Android application that lets you run Windows applications with W
 
 # Winlator versions
 
-[Official Winlator](https://github.com/brunodev85/winlator) by Brunodev  
-[Winlator Cmod](https://github.com/coffincolors/winlator/releases) by Coffincolors  
-[Winlator Cmod Bionic](https://github.com/jhinzuo/winlator_bionic/releases) by Coffincolors & Pissblaster
-* [Jhinzou Fork](https://github.com/jhinzuo/winlator/releases)  
+[Official Winlator](https://github.com/brunodev85/winlator) by Brunodev
+[Winlator Cmod](https://github.com/coffincolors/winlator/releases) by Coffincolors
+[Winlator Cmod Bionic](https://github.com/jhinzuo/winlator/releases) by Coffincolors & Pissblaster
+* [Jhinzou Fork](https://github.com/jhinzuo/winlator/releases)
 * [Succubus Fork](https://github.com/Succubussix/winlator-bionic-glibc/releases/tag/Personalize)
 
-[Winlator Afeimod](https://github.com/afeimod/winlator-mod/releases/)  
-[Winlator Frost](https://github.com/MrPhryaNikFrosty/Winlator-Frost/releases)  
-[Winlator AJAY](https://github.com/ajay9634/winlator-ajay/releases)  
-[Winlator Longjunyu2](https://github.com/longjunyu2/winlator/releases) (development paused)  
-[WinlatorMali](https://github.com/Fcharan/WinlatorMali/releases) (probably ceased)  
+[Winlator Afeimod](https://github.com/afeimod/winlator-mod/releases/)
+[Winlator Frost](https://github.com/MrPhryaNikFrosty/Winlator-Frost/releases)
+[Winlator AJAY](https://github.com/ajay9634/winlator-ajay/releases) (repository archived)
+[Winlator Longjunyu2](https://github.com/longjunyu2/winlator/releases) (development paused)
+[WinlatorMali](https://github.com/Fcharan/WinlatorMali/releases) (probably ceased)
 
 
 # Compatibility list  

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Winlator logs can be located in the `Interal Storage/Download/Winlator/logs`
 * Containers
   * [Containers Cmod Bionic]
 * [Input Controls](/docs/input_controls.md)
-  * [Controls Editor](/docs/controls_editor.md)
+  * [Controls Editor](/docs/condrols_editor.md)
   * [External Controller Editor](/docs/external_controllers_editor.md)
 * Saves
-* Box64 RCFile
+* [Box64 RCFile](/docs/box_rc_file.md)
 * Contents
 * Adrenotools GPU Drivers (Winlator Bionic)
 * Settings

--- a/docs/box_rc_file.md
+++ b/docs/box_rc_file.md
@@ -1,1 +1,111 @@
+# Box64 `.rcp` Files in Winlator
 
+In Winlator, `.rcp` files are JSON-formatted configuration files that allow
+users to define environment variables for specific Windows executables.
+
+These files enable fine-tuning of the Box64 emulator's behavior on a
+per-application basis, optimizing performance and compatibility.
+
+---
+
+## What Is an `.rcp` File?
+
+An `.rcp` (Runtime Configuration Profile) file contains structured data that specifies environment variables for individual Windows processes. These variables adjust how Box64 emulates x86_64 applications within Winlator.
+
+The `.rcp` format is unique to Winlator and is not directly compatible with standard Box64 `.box64rc` files. However, `.rcp` files can be used to generate `.box64rc` configurations that Box64 can interpret.
+
+---
+
+## Why Use `.rcp` Files?
+
+RC files are an alternative to adding games as _shortcuts_ in Winlator.
+They let you configure settings for specific executables, but in a more
+flexible and sharable way. While shortcuts and RC files support different
+types of configuration, the big advantage of RC files is that they can be
+easily shared and reused.
+
+With community effort, they can grow into large collections of
+pre-configured settings for games that need tweaks to run
+well in Winlator.
+
+> A good example is the “Luis Gaming” RC file, which comes bundled with
+> many forks of Winlator and includes settings for a wide range of games.
+
+## File Structure
+
+An `.rcp` file is a JSON object with the following structure:
+
+- `id`: A unique identifier for the profile.
+- `name`: The name of the profile.
+- `groups`: An array of groups, each containing:
+  - `name`: The group's name.
+  - `desc`: A description of the group (optional).
+  - `enabled`: A boolean indicating if the group is active.
+  - `items`: An array of items, each specifying:
+    - `processName`: The name of the executable.
+    - `desc`: A description of the item (optional).
+    - `vars`: A dictionary of environment variables and their values.
+
+---
+
+## 🛠️ Example `.rcp` Configuration
+
+```json
+{
+  "name": "Assassin's Creed\/Splinter Cell",
+  "desc": "",
+  "enabled": true,
+  "items": [
+    {
+      "processName": "AssassinsCreedII.exe",
+      "desc": "",
+      "vars": {
+        "BOX64_DYNAREC_BIGBLOCK": "3",
+        "BOX64_DYNAREC_CALLRET": "0",
+        "BOX64_DYNAREC_FASTNAN": "1",
+        "BOX64_DYNAREC_FASTROUND": "1",
+        "BOX64_DYNAREC_SAFEFLAGS": "2",
+        "BOX64_MAXCPU": "4"
+      }
+    },
+    {
+      "processName": "AssassinsCreedIIGame.exe",
+      "desc": "",
+      "vars": {
+        "BOX64_DYNAREC_BIGBLOCK": "3",
+        "BOX64_DYNAREC_CALLRET": "0",
+        "BOX64_DYNAREC_FASTNAN": "1",
+        "BOX64_DYNAREC_FASTROUND": "1",
+        "BOX64_DYNAREC_SAFEFLAGS": "2",
+        "BOX64_MAXCPU": "4"
+      }
+    },
+    {
+      "processName": "Blacklist_game.exe",
+      "desc": "",
+      "vars": {
+        "BOX64_DYNAREC_BIGBLOCK": "3",
+        "BOX64_DYNAREC_CALLRET": "0",
+        "BOX64_DYNAREC_FASTNAN": "1",
+        "BOX64_DYNAREC_FASTROUND": "1",
+        "BOX64_DYNAREC_SAFEFLAGS": "2",
+        "BOX64_MAXCPU": "4"
+      }
+    },
+    {
+      "processName": "conviction_game.exe",
+      "desc": "",
+      "vars": {
+        "BOX64_DYNAREC_BIGBLOCK": "3",
+        "BOX64_DYNAREC_CALLRET": "0",
+        "BOX64_DYNAREC_FASTNAN": "1",
+        "BOX64_DYNAREC_FASTROUND": "1",
+        "BOX64_DYNAREC_SAFEFLAGS": "2",
+        "BOX64_MAXCPU": "4"
+      }
+    }
+  ]
+}
+```
+
+[TODO] Add examples with screen captures of Winlator


### PR DESCRIPTION
📄 Added initial documentation for `box64_rc_file.md` to help users understand and use RC files in Winlator.

⚙️ Added SD865 to the list of supported SoCs when creating an _issue_.

🧹 Fixed a broken link
🧹 removed extra whitespace
🧹 added a note indicating that a referenced repo is archived.